### PR TITLE
api subcommands

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -24,6 +24,9 @@ fn main() {
         .about("Show a document's timestamping status.")
         .arg_from_usage("<ID> 'The document unique ID'")
       )
+      .subcommand(
+        SubCommand::with_name("website-verifications").about("Shows the status of your website verification")
+      )
     )
     .subcommand(
       SubCommand::with_name("stamp")
@@ -129,6 +132,8 @@ fn main() {
           .unwrap()
           .as_bytes()
           .to_vec()
+      } else if sub.is_present("website-verifications") {
+        client.website_verifications(true).unwrap().as_bytes().to_vec()
       } else {
         help
       }
@@ -156,7 +161,7 @@ fn main() {
       verify_website_flow(&client, &sub.value_of("URL").expect("URL TO BE SET"))
         .as_bytes()
         .to_vec(),
-    ("website-verifications", Some(_)) => client.website_verifications().unwrap().as_bytes().to_vec(),
+    ("website-verifications", Some(_)) => client.website_verifications(false).unwrap().as_bytes().to_vec(),
     ("account-state", Some(_)) => client
       .account_state().unwrap().as_bytes().to_vec(),
     _ => help,

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -19,6 +19,11 @@ fn main() {
       .subcommand(
         SubCommand::with_name("list").about("List all your documents")
       )
+      .subcommand(
+        SubCommand::with_name("show")
+        .about("Show a document's timestamping status.")
+        .arg_from_usage("<ID> 'The document unique ID'")
+      )
     )
     .subcommand(
       SubCommand::with_name("stamp")
@@ -118,6 +123,12 @@ fn main() {
           .to_vec()
       } else if sub.is_present("list") {
         client.documents().unwrap().as_bytes().to_vec()
+      } else if let Some(show) = sub.subcommand_matches("show") {
+        client
+          .document(&show.value_of("ID").unwrap(), true)
+          .unwrap()
+          .as_bytes()
+          .to_vec()
       } else {
         help
       }
@@ -129,7 +140,7 @@ fn main() {
       .to_vec(),
     ("list", Some(_)) => client.list_documents().unwrap().as_bytes().to_vec(),
     ("show", Some(sub)) => client
-      .document(&sub.value_of("ID").unwrap())
+      .document(&sub.value_of("ID").unwrap(), false)
       .unwrap()
       .as_bytes()
       .to_vec(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ struct AccountState {
 
 #[derive(Serialize, Deserialize)]
 struct DocumentBundle {
-  bulletin_id: Number,
+  bulletin_id: Option<Number>,
   cost: String,
   created_at: String,
   gift_id: Value,
@@ -148,7 +148,10 @@ impl Client {
     } else {
       println!("{} {}", style("Document state:").bold().bright(), response.state);
       println!("{} {}", style("Document id:").bold().bright(), response.id);
-      println!("{} {}", style("Bulletin id:").bold().bright(), response.bulletin_id);
+      match response.bulletin_id {
+        Some(bulletin_id) => println!("{} {}", style("Bulletin id:").bold().bright(), bulletin_id),
+        None => {}
+      }
       println!("{} {}", style("Cost:").bold().bright(), response.cost);
       println!("{} {}", style("Created At:").bold().bright(), response.created_at);
       println!("{} {}", style("Buy token link:").bold().bright(), response.buy_tokens_link);
@@ -234,7 +237,7 @@ impl Client {
     println!("{} {} {}", Emoji("📑", "*"), style("Total Documents:").bold().bright(), documents.len());
     println!("{}", style("Document ID / Bulletin ID:").bold().bright());
     for document in documents {
-      println!("  {} / {}", document.id, document.bulletin_id )
+      println!("  {} / {}", document.id, document.bulletin_id.unwrap() )
     }
     Ok("".to_string())
   }
@@ -246,7 +249,7 @@ impl Client {
     } else {
       println!("{} {}", style("Document state:").bold().bright(), response.state);
       println!("{} {}", style("Document id:").bold().bright(), response.id);
-      println!("{} {}", style("Bulletin id:").bold().bright(), response.bulletin_id);
+      println!("{} {}", style("Bulletin id:").bold().bright(), response.bulletin_id.unwrap());
       println!("{} {}", style("Cost:").bold().bright(), response.cost);
       println!("{} {}", style("Created At:").bold().bright(), response.created_at);
       Ok("".to_string())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,7 @@ use signature::Signature;
 
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use serde_json::Number;
-use serde_json::Value;
+use serde_json::{Number, Value};
 use bitcoin::PublicKey;
 
 use dialoguer::console::{Emoji, style};
@@ -46,7 +45,7 @@ struct AccountState {
 
 #[derive(Serialize, Deserialize)]
 struct DocumentBundle {
-  bulletins: Value,
+  bulletin_id: Number,
   cost: String,
   created_at: String,
   gift_id: Value,
@@ -133,6 +132,7 @@ impl Client {
     } else {
       println!("{} {}", style("Document state:").bold().bright(), response.state);
       println!("{} {}", style("Document id:").bold().bright(), response.id);
+      println!("{} {}", style("Bulletin id:").bold().bright(), response.bulletin_id);
       println!("{} {}", style("Cost:").bold().bright(), response.cost);
       println!("{} {}", style("Created At:").bold().bright(), response.created_at);
       println!("{} {}", style("Buy token link:").bold().bright(), response.buy_tokens_link);
@@ -197,19 +197,32 @@ impl Client {
     self.sign_and_timestamp(&file_path, api_response)
   }
 
-  pub fn documents(&self) -> Result<String> {
+  pub fn documents(&self,) -> Result<String> {
     self.get_json("/documents")
   }
 
   pub fn list_documents(&self) -> Result<String> {
     let documents: Vec<DocumentBundle> = serde_json::from_slice(self.get_json("/documents").unwrap().as_bytes())?;
-    println!("\n {} {} {}\n", Emoji("📑", "*"), style("Total Documents:").bold().bright(), documents.len());
+    println!("{} {} {}", Emoji("📑", "*"), style("Total Documents:").bold().bright(), documents.len());
+    println!("{}", style("Document ID / Bulletin ID:").bold().bright());
+    for document in documents {
+      println!("  {} / {}", document.id, document.bulletin_id )
+    }
     Ok("".to_string())
   }
 
-  pub fn document(&self, document_id: &str) -> Result<String> {
+  pub fn document(&self, document_id: &str, api_response: bool) -> Result<String> {
     let response: DocumentBundle = self.get_response(&format!("/documents/{}", document_id))?.into_json()?;
-    Ok(serde_json::to_string_pretty(&response)?)
+    if api_response {
+      Ok(serde_json::to_string_pretty(&response)?)
+    } else {
+      println!("{} {}", style("Document state:").bold().bright(), response.state);
+      println!("{} {}", style("Document id:").bold().bright(), response.id);
+      println!("{} {}", style("Bulletin id:").bold().bright(), response.bulletin_id);
+      println!("{} {}", style("Cost:").bold().bright(), response.cost);
+      println!("{} {}", style("Created At:").bold().bright(), response.created_at);
+      Ok("".to_string())
+    }
   }
 
   pub fn fetch_proof(&self, document_id: &str) -> Result<String> {
@@ -279,17 +292,16 @@ r#"{
     let mock = mockito::mock("GET", "/documents/1")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"state":"Parked","id":"1-1","person_id":1,"parts":[{"id":"bc","document_id":"1-9","friendly_name":"doc","hash":"9","content_type":"multipart/alternative","size_in_bytes":1410,"signatures":[{"id":4,"document_part_id":"bc","pubkey_id":"mw","signature":"HN","signature_hash":"be","endorsements":[]}],"is_base":true},{"id":"f1","document_id":"1-9","friendly_name":"hello.txt","hash":"68","content_type":"text/plain","size_in_bytes":59,"signatures":[],"is_base":false},{"id":"9f","document_id":"1-9","friendly_name":"unnamed_attachment.txt","hash":"6f","content_type":"text/html","size_in_bytes":94,"signatures":[],"is_base":false},{"id":"b6","document_id":"1-9","friendly_name":"unnamed_attachment.zip","hash":"83","content_type":"application/zip","size_in_bytes":530,"signatures":[],"is_base":false},{"id":"c7","document_id":"1-95","friendly_name":"bar/baz.txt","hash":"bf0","content_type":"text/plain","size_in_bytes":4,"signatures":[],"is_base":false},{"id":"59","document_id":"1-99","friendly_name":"foo.txt","hash":"b5","content_type":"text/plain","size_in_bytes":4,"signatures":[],"is_base":false}],"created_at":"2022-01-05T08:04:47.166681Z","cost":"1","gift_id":null,"bulletins":{},"buy_tokens_link":"https://localhost:8000/invoices/#link_token=boss+almighty+registrar+ashes+unsalted&minimum_suggested=4"}"#)
+        .with_body(r#"{"state":"Parked","id":"1-1","person_id":1,"bulletin_id": 303, "parts":[{"id":"bc","document_id":"1-9","friendly_name":"doc","hash":"9","content_type":"multipart/alternative","size_in_bytes":1410,"signatures":[{"id":4,"document_part_id":"bc","pubkey_id":"mw","signature":"HN","signature_hash":"be","endorsements":[]}],"is_base":true},{"id":"f1","document_id":"1-9","friendly_name":"hello.txt","hash":"68","content_type":"text/plain","size_in_bytes":59,"signatures":[],"is_base":false},{"id":"9f","document_id":"1-9","friendly_name":"unnamed_attachment.txt","hash":"6f","content_type":"text/html","size_in_bytes":94,"signatures":[],"is_base":false},{"id":"b6","document_id":"1-9","friendly_name":"unnamed_attachment.zip","hash":"83","content_type":"application/zip","size_in_bytes":530,"signatures":[],"is_base":false},{"id":"c7","document_id":"1-95","friendly_name":"bar/baz.txt","hash":"bf0","content_type":"text/plain","size_in_bytes":4,"signatures":[],"is_base":false},{"id":"59","document_id":"1-99","friendly_name":"foo.txt","hash":"b5","content_type":"text/plain","size_in_bytes":4,"signatures":[],"is_base":false}],"created_at":"2022-01-05T08:04:47.166681Z","cost":"1","gift_id":null,"bulletins":{},"buy_tokens_link":"https://localhost:8000/invoices/#link_token=boss+almighty+registrar+ashes+unsalted&minimum_suggested=4"}"#)
         .expect(1)
         .create();
 
-    let json_response = client.document(&"1".to_string()).unwrap();
+    let json_response = client.document(&"1".to_string(), true).unwrap();
 
     assert_eq!(
       json_response,
-      
 r#"{
-  "bulletins": {},
+  "bulletin_id": 303,
   "cost": "1",
   "created_at": "2022-01-05T08:04:47.166681Z",
   "gift_id": null,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ struct PubkeyDomainEndorsement {
   next_attempt: String,
   pubkey_id: String,
   request_signature: String,
+  state: String,
 }
 
 
@@ -172,13 +173,13 @@ impl Client {
     if api_response {
       self.get_json("/pubkey_domain_endorsements")
     } else {
-      let response: Vec<PubkeyDomainEndorsement> = self.get_response("/pubkey_domain_endorsements")?.into_json()?;
+      let response: Vec<PubkeyDomainEndorsement> = serde_json::from_slice(self.get_json("/pubkey_domain_endorsements").unwrap().as_bytes())?;
       for site in response {
         println!("{} {}", style("Site:").bold().bright(), site.domain);
-        // println!("{} {}", style("Verification state:").bold().bright(), site.state);
-        // if site.state != "accepted" {
+        println!("{} {}", style("Verification state:").bold().bright(), site.state);
+        if site.state != "accepted" {
           println!("{} {}\n", style("Attempts:").bold().bright(), site.attempts);
-        // }
+        }
       }
       Ok("".to_string())
     }


### PR DESCRIPTION
- [x] subcommands `stamp` and `list` with "friendly response"

- [x] same subcommands with JSON response move behind `api` argument